### PR TITLE
Mac build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ node-cryptonight requires [Boost](http://www.boost.org)
 
     sudo apt-get install libboost-all-dev
 
+##### Mac
+
+    brew install boost
+
 ### Installation
 
     npm install --save node-cryptonight

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,13 @@
       "include_dirs": [
 	"<!(node -e \"require('nan')\")"
       ],
+      "xcode_settings": {
+        "OTHER_CFLAGS": [
+          "-maes",
+          "-Ofast",
+          "-fexceptions"
+        ]
+      },
       "cflags": [
         "-maes",
         "-Ofast",


### PR DESCRIPTION
I was frustrated to find that node-gyp did not behave the same on Mac and Linux. When trying to build on Mac I received the error message:  

`./lib/vendor/slow-hash.c:594:18: error: always_inline function '_mm_aesenc_si128' requires target feature 'aes', but would be inlined into function 'cn_slow_hash' that is compiled without support for 'aes'`

After much searching, it seems that an additional section in `bindings.gyp` is required for xcode. It now seems to build correctly on Mac and Linux.

Thanks,
Owen